### PR TITLE
addons: Add network:wikidata tag

### DIFF
--- a/src/main/java/org/openmaptiles/addons/OsmTags.java
+++ b/src/main/java/org/openmaptiles/addons/OsmTags.java
@@ -18,6 +18,7 @@ public class OsmTags {
     "email",
     "internet_access",
     "level:ref",
+    "network:wikidata",
     "note",
     "opening_hours",
     "phone",


### PR DESCRIPTION
I was playing with idea of showing customized icons for metro/subway/rail stations in Maps (similar to highway shields).

One idea is to use network:wikidata rather than relying on "network" (which could have duplicate values in different networks).