### PR TITLE
Add private

### DIFF
--- a/src/main/java/org/openmaptiles/addons/OsmTags.java
+++ b/src/main/java/org/openmaptiles/addons/OsmTags.java
@@ -23,6 +23,7 @@ public class OsmTags {
     "opening_hours",
     "phone",
     "population",
+    "private",
     "religion",
     "sport",
     "takeaway",


### PR DESCRIPTION
Adds the private tag to addons.

See also: https://gitlab.gnome.org/GNOME/gnome-maps/-/issues/681

I guess an alternative could also be to have it being skipped when generating the "poi" layer altogether…