### PR TITLE
addons: Add level

### DIFF
--- a/src/main/java/org/openmaptiles/addons/OsmTags.java
+++ b/src/main/java/org/openmaptiles/addons/OsmTags.java
@@ -17,6 +17,7 @@ public class OsmTags {
     "ele",
     "email",
     "internet_access",
+    "level",
     "level:ref",
     "network:wikidata",
     "note",


### PR DESCRIPTION
We already include level:ref.
In GNOME Maps, we use either level:ref, or level
(relative floor level from ground level).
Having this in the tiles would enable us to
eventually stop using Overpass to load tags.