### PR TITLE
addons: Add "access" OSM tag

### DIFF
--- a/src/main/java/org/openmaptiles/addons/OsmTags.java
+++ b/src/main/java/org/openmaptiles/addons/OsmTags.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 public class OsmTags {
   private static final HashSet<String> OSM_TAGS = new HashSet<String>(List.of(
+    "access",
     "brand:wikidata",
     "brand:wikipedia",
     "cuisine",


### PR DESCRIPTION
Sorry, creating some addional noice here :-)

Just added the "private" tag before.
But I now realized that tagging
private=yes

seems to be kinda deprecated,

It looks like that preferred way (and I've seen this on e.g. parking spaces) would something like:

access=private
private=residents

I think still having private could be useful, as that would allow more fine-grained filtering, or showing additional information on features.